### PR TITLE
Avoid recomputation of sites (and other bugfixes)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "DiscreteVoronoi"
 uuid = "01fd5c3e-b3b7-45fb-9d19-e82518019796"
 authors = ["Jacobus Smit <jacobusmmsmit@gmail.com>", "Jörg Walter <undisclosed>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,9 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "1.8"
 Distances = "^0.10"
 StaticArrays = "^1"
+julia = "1.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiscreteVoronoi"
 uuid = "01fd5c3e-b3b7-45fb-9d19-e82518019796"
 authors = ["Jacobus Smit <jacobusmmsmit@gmail.com>", "Jörg Walter <undisclosed>"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiscreteVoronoi"
 uuid = "01fd5c3e-b3b7-45fb-9d19-e82518019796"
 authors = ["Jacobus Smit <jacobusmmsmit@gmail.com>", "Jörg Walter <undisclosed>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,9 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-StaticArrays = "1"
 julia = "1.8"
+Distances = "^0.10"
+StaticArrays = "^1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ There are currently three ways of computing discrete Voronoi diagrams exported, 
 Which algorithm you should use for the fastest execution time depends somewhat on the task at hand. The best thing to do is to try all above for your usecase and decide from benchmarks. As a rule of thumb, the larger the grid is the better the divide-and-conquer methods will be in comparison. Particularly if the number of sites scales with the size of the grid (`n^2`) faster than `log(n)` (natural log), then `redac_voronoi!` will be much faster than `dac_voronoi!`. 
 
 Additionally, the package exports some helper functions for analysing Voronoi diagrams and writing your own algorithms:
-* `find_closest_site` finds the closest site to a specified cell in the Lp sense.
+* `find_closest_site` and `find_closest_site!` finds the closest site to a specified cell in the Lp sense, the latter writing it directly to the grid if it hasn't already been calculated.
 * `get_corners` and `get_quadrants` take the top-left (TL) and bottom-right (BR) corners of a rectangle and return the TL and BR corners, and non-overlapping quadrants (calculated by integer division) respectively.
 * `label_voronoi_grid` takes a grid of `SVector{2, Int}` and labels each unique value with an integer in a new grid of the same size so it can be visualised.
 * `voronoi_equality` can be used to test equality of resulting Voronoi diagrams taking into account that some sites may be the same distance from certain cells and so there are multiple valid/correct diagrams that could be produced.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Additionally, the package exports some helper functions for analysing Voronoi di
 * `voronoi_equality` can be used to test equality of resulting Voronoi diagrams taking into account that some sites may be the same distance from certain cells and so there are multiple valid/correct diagrams that could be produced.
 
 ## Work in progress:
- * Support for arbitrary distance functions.
  * Implementing a hybrid version of `redac_voronoi!` and `dac_voronoi!` that switches to `naive_voronoi!` once a certain size is reached.
  * Currently, I have not implemented multithreaded (or GPU in the case of JFA) versions of these algorithms on the main branch, but the legacy branch contains versions of the algorithms that do have this capability.
 

--- a/src/DiscreteVoronoi.jl
+++ b/src/DiscreteVoronoi.jl
@@ -11,6 +11,7 @@ export naive_voronoi!, jfa_voronoi!, dac_voronoi!, redac_voronoi! # Core functio
 using LinearAlgebra: norm
 using Random: shuffle
 using StaticArrays
+using Distances: euclidean
 
 # Completely non-exported files with core definitions
 include("EarlyStopper.jl") # Because every package needs at least one struct...

--- a/src/DiscreteVoronoi.jl
+++ b/src/DiscreteVoronoi.jl
@@ -3,13 +3,15 @@ module DiscreteVoronoi
 #TODO: Implement hybrid algorithms for certain gridsize and number of sites.
 #TODO: Add nice UnicodePlot recipe :)
 
-export find_closest_site, get_corners, get_quadrants, label_voronoi_grid, voronoi_equality # Helper functions
+export find_closest_site, find_closest_site!, get_corners, get_quadrants, label_voronoi_grid, voronoi_equality # Helper functions
 export naive_voronoi!, jfa_voronoi!, dac_voronoi!, redac_voronoi! # Core functionality
 
 using LinearAlgebra: norm
 using Random: shuffle
 using StaticArrays
 using Distances: euclidean
+
+Coord = SVector{2,Int}
 
 # Completely non-exported files with core definitions
 include("EarlyStopper.jl") # Because every package needs at least one struct...

--- a/src/DiscreteVoronoi.jl
+++ b/src/DiscreteVoronoi.jl
@@ -1,7 +1,5 @@
 module DiscreteVoronoi
 
-#TODO: Allow user to select p
-#TODO: Allow user to input an arbitrary distance function
 #TODO: Implement hybrid algorithms for certain gridsize and number of sites.
 #TODO: Add nice UnicodePlot recipe :)
 

--- a/src/core_algorithms.jl
+++ b/src/core_algorithms.jl
@@ -63,6 +63,7 @@ function dac_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean) whe
 end
 
 @inbounds function _dac_voronoi!(grid, TL, BR, sites; distance)
+    any(TL .> BR) && return nothing
     if all(BR .== TL)
         grid[TL...] = find_closest_site(TL, sites, distance=distance)
     elseif length(sites) == 1 # Same if there is a single site
@@ -97,6 +98,7 @@ function redac_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean, a
 end
 
 @inbounds function _redac_voronoi!(grid, TL, BR, sites::ES; distance, auxiliary) where {ES<:EarlyStopper}
+    any(TL .> BR) && return nothing
     # Then, if the grid is a single cell then we are done
     if all(BR .== TL)
         grid[TL...] = find_closest_site(TL, sites, distance=distance)

--- a/src/core_algorithms.jl
+++ b/src/core_algorithms.jl
@@ -93,7 +93,7 @@ step which aims to reduce the work of subsequent steps.
 function redac_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean, auxiliary=exact_aux) where {T<:SVector{2,Int}}
     TL = 1, 1
     BR = size(grid)
-    _redac_voronoi!(grid, TL, BR, EarlyStopper(sites); distance=distance, auxiliary=exact_aux)
+    _redac_voronoi!(grid, TL, BR, EarlyStopper(sites); distance=distance, auxiliary=auxiliary)
     return nothing
 end
 

--- a/src/core_algorithms.jl
+++ b/src/core_algorithms.jl
@@ -5,24 +5,24 @@
 # multithreaded in its current state as it heavily mutates its arguments.
 
 """
-    naive_voronoi!(grid, sites::T, p=2) where {T<:Vector{SVector{2,Int}}}
+    naive_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean) where {T<:SVector{2,Int}}
 
 Construct in-place a Voronoi diagram in the most basic way possible: check every cell and every combination.
 """
-function naive_voronoi!(grid, sites::T, p=2) where {T<:Vector{SVector{2,Int}}}
+function naive_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean) where {T<:SVector{2,Int}}
     for I in CartesianIndices(grid)
-        @inbounds grid[I] = find_closest_site(Tuple(I), sites, p)
+        @inbounds grid[I] = find_closest_site(Tuple(I), sites; distance=distance)
     end
     return nothing
 end
 
 """
-    jfa_voronoi!(grid, sites::T, p=2) where {T<:Vector{SVector{2,Int}}}
+    jfa_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean) where {T<:SVector{2,Int}}
 
 Construct in-place a Voronoi diagram using the [jump flooding algorithm](https://en.wikipedia.org/wiki/Jump_flooding_algorithm).
 The algorithm assumes that a blank cell in the grid has value `SVector(0, 0)` and that sites are inside the grid.
 """
-function jfa_voronoi!(grid, sites::T, p=2) where {T<:Vector{SVector{2,Int}}}
+function jfa_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean) where {T<:SVector{2,Int}}
     for site in sites
         # Splatting (grid[site...] = site) causes allocations?
         x, y = site
@@ -41,7 +41,7 @@ function jfa_voronoi!(grid, sites::T, p=2) where {T<:Vector{SVector{2,Int}}}
                 sitep = grid[x, y]
                 if sitep == SVector(0, 0)
                     grid[x, y] = siteq
-                elseif distance(sitep, (x, y), p) > distance(siteq, (x, y), p)
+                elseif distance(sitep, (x, y)) > distance(siteq, (x, y))
                     grid[x, y] = siteq
                 end
             end
@@ -51,32 +51,32 @@ function jfa_voronoi!(grid, sites::T, p=2) where {T<:Vector{SVector{2,Int}}}
 end
 
 """
-    dac_voronoi!(grid, sites::T, p=2) where {T<:Vector{SVector{2,Int}}}
+    dac_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean) where {T<:SVector{2,Int}}
 
 Construct in-place a Voronoi diagram using the [divide-and-conquer algorithm](https://doi.org/10.1109%2Feit48999.2020.9208270).
 """
-function dac_voronoi!(grid, sites::T, p=2) where {T<:Vector{SVector{2,Int}}}
+function dac_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean) where {T<:SVector{2,Int}}
     TL = (1, 1)
     BR = size(grid)
-    _dac_voronoi!(grid, TL, BR, sites, p)
+    _dac_voronoi!(grid, TL, BR, sites, distance=distance)
     return nothing
 end
 
-@inbounds function _dac_voronoi!(grid, TL, BR, sites, p)
+@inbounds function _dac_voronoi!(grid, TL, BR, sites; distance)
     if all(BR .== TL)
-        grid[TL...] = find_closest_site(TL, sites, p)
+        grid[TL...] = find_closest_site(TL, sites, distance=distance)
     elseif length(sites) == 1 # Same if there is a single site
         view(grid, TL[1]:BR[1], TL[2]:BR[2]) .= Ref(first(sites))
     else
         # Otherwise we check if all corners have the same closest site
         corners = get_corners(TL, BR)
-        closest_corners = (find_closest_site(corner, sites, p) for corner in corners)
+        closest_corners = (find_closest_site(corner, sites, distance=distance) for corner in corners)
         if allequal(closest_corners)
             grid[TL[1]:BR[1], TL[2]:BR[2]] .= Ref(first(closest_corners))
         else
             # And if not we divide the grid into quadrants and "conquer" each one
             for (quadrant_TL, quadrant_BR) in get_quadrants(TL, BR)
-                _dac_voronoi!(grid, quadrant_TL, quadrant_BR, sites, p)
+                _dac_voronoi!(grid, quadrant_TL, quadrant_BR, sites; distance=distance)
             end
         end
     end
@@ -84,39 +84,37 @@ end
 end
 
 """
-    redac_voronoi!(grid, sites::T; p=2, auxiliary=exact_aux) where {T<:Vector{SVector{2,Int}}}
+    redac_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean, auxiliary=exact_aux) where {T<:SVector{2,Int}}
 
 Performs a divide-and-conquer method similar to `dac_voronoi!` but has an additional site-elimination
 step which aims to reduce the work of subsequent steps.
 """
-function redac_voronoi!(
-    grid, sites::T; p=2, auxiliary=exact_aux
-) where {T<:Vector{SVector{2,Int}}}
+function redac_voronoi!(grid::Matrix{T}, sites::Vector{T}; distance=euclidean, auxiliary=exact_aux) where {T<:SVector{2,Int}}
     TL = 1, 1
     BR = size(grid)
-    _redac_voronoi!(grid, TL, BR, EarlyStopper(sites), p, auxiliary)
+    _redac_voronoi!(grid, TL, BR, EarlyStopper(sites); distance=distance, auxiliary=exact_aux)
     return nothing
 end
 
-@inbounds function _redac_voronoi!(grid, TL, BR, sites::ES, p, auxiliary) where {ES<:EarlyStopper}
+@inbounds function _redac_voronoi!(grid, TL, BR, sites::ES; distance, auxiliary) where {ES<:EarlyStopper}
     # Then, if the grid is a single cell then we are done
     if all(BR .== TL)
-        grid[TL...] = find_closest_site(TL, sites, p)
+        grid[TL...] = find_closest_site(TL, sites, distance=distance)
     elseif length(sites) == 1 # Same if there is a single site
         view(grid, TL[1]:BR[1], TL[2]:BR[2]) .= Ref(first(sites))
     else
         # Otherwise we check if all corners have the same closest site
         corners = get_corners(TL, BR)
-        closest_corners = (find_closest_site(corner, sites, p) for corner in corners)
+        closest_corners = (find_closest_site(corner, sites, distance=distance) for corner in corners)
         if allequal(closest_corners)
             view(grid, TL[1]:BR[1], TL[2]:BR[2]) .= Ref(first(closest_corners))
         else
             # And if not we eliminate faraway seeds from subsequent steps
             # `auxiliary` sorts sites by whether the predicate is true and stores how many are true.
-            local_sites = auxiliary(sites, TL, BR)
+            local_sites = auxiliary(sites, TL, BR; distance=distance)
             # then divide the grid into quadrants and "conquer" each one
             for (quadrant_TL, quadrant_BR) in get_quadrants(TL, BR)
-                _redac_voronoi!(grid, quadrant_TL, quadrant_BR, local_sites, p, auxiliary)
+                _redac_voronoi!(grid, quadrant_TL, quadrant_BR, local_sites; distance=distance, auxiliary=auxiliary)
             end
         end
     end

--- a/src/elimination_methods.jl
+++ b/src/elimination_methods.jl
@@ -1,7 +1,7 @@
 # This is non-exported, non-userfacing code.
 # This file contains the elimination methods used in `redac_voronoi!`.
 
-function exact_condition(site, sites, TL, BR)
+function exact_condition(site, sites, TL, BR; distance=euclidean)
     for other_site in sites
         site == other_site && continue
         if all(
@@ -14,14 +14,14 @@ function exact_condition(site, sites, TL, BR)
     return true
 end
 
-function centre_anchor_condition(site, sites, TL, BR)
+function centre_anchor_condition(site, sites, TL, BR; distance=euclidean)
     centre = @. TL + BR / 2
     anchor = find_closest_site(centre, sites)
     corners = get_corners(TL, BR)
     return any(distance(site, corner) <= distance(anchor, corner) for corner in corners)
 end
 
-function centre_anchor_aux(sites, TL, BR)
+function centre_anchor_aux(sites, TL, BR; distance=euclidean)
     centre = @. TL + BR / 2
     anchor = find_closest_site(centre, sites)
     corners = get_corners(TL, BR)
@@ -32,8 +32,8 @@ function centre_anchor_aux(sites, TL, BR)
     return early_stop_sort!(sites, predicate)
 end
 
-function exact_aux(sites, TL, BR)
-    predicate(site) = all(TL .<= site .<= BR) || exact_condition(site, sites, TL, BR)
+function exact_aux(sites, TL, BR; distance=euclidean)
+    predicate(site) = all(TL .<= site .<= BR) || exact_condition(site, sites, TL, BR; distance=distance)
     return early_stop_sort!(sites, predicate)
 end
 

--- a/src/elimination_methods.jl
+++ b/src/elimination_methods.jl
@@ -21,7 +21,7 @@ function centre_anchor_condition(site, sites, TL, BR; distance=euclidean)
     return any(distance(site, corner) <= distance(anchor, corner) for corner in corners)
 end
 
-function centre_anchor_aux(sites, TL, BR; distance=euclidean)
+function centre_anchor_aux(grid, sites, TL, BR; distance=euclidean)
     centre = @. TL + BR / 2
     anchor = find_closest_site(centre, sites)
     corners = get_corners(TL, BR)
@@ -32,43 +32,36 @@ function centre_anchor_aux(sites, TL, BR; distance=euclidean)
     return early_stop_sort!(sites, predicate)
 end
 
-function exact_aux(sites, TL, BR; distance=euclidean)
+function exact_aux(grid, sites, TL, BR; distance=euclidean)
     predicate(site) = all(TL .<= site .<= BR) || exact_condition(site, sites, TL, BR; distance=distance)
     return early_stop_sort!(sites, predicate)
 end
 
-function edge_aux(sites, TL, BR; distance=euclidean)
+function naive_edge_aux!(grid, sites, TL, BR; distance=euclidean)
     corners = get_corners(TL, BR)
-    keep_per_edge = Iterators.map(1:4) do i
-        j = mod(i, 4) + 1
-        edge_cells = get_edge(corners[i], corners[j])
-        return Iterators.map(cell -> find_closest_site(cell, sites; distance=distance), edge_cells)
-    end
-    sites_to_keep = Iterators.flatten(keep_per_edge)
+    coordinates = (CartesianIndex(corners[a]...):CartesianIndex(corners[b]...) for (a, b) in zip((1, 1, 2, 4), (2, 4, 3, 3)))
+    sites_to_keep = (find_closest_site!(grid, Coord(Tuple(I)), sites; distance=distance) for I in coordinates)
     predicate(site) = all(TL .<= site .<= BR) || site in sites_to_keep
     return early_stop_sort!(sites, predicate)
 end
 
-function dac_edge_aux(sites, TL, BR; distance=euclidean)
+function dac_edge_aux!(grid, sites, TL, BR; distance=euclidean)
     corners = get_corners(TL, BR)
-    keep_per_edge = Iterators.map(1:4) do i
-        j = mod(i, 4) + 1
-        return edge_dac(sites, corners[i], corners[j]; distance=distance)
-    end
-    sites_to_keep = Iterators.flatten(keep_per_edge)
+    edges = ((corners[a], corners[b]) for (a, b) in zip((1, 1, 2, 4), (2, 4, 3, 3)))
+    sites_to_keep = (edge_dac!(grid, sites, edge[1], edge[2], distance=distance) for edge in edges)
     predicate(site) = all(TL .<= site .<= BR) || site in sites_to_keep
     return early_stop_sort!(sites, predicate)
 end
 
-function edge_dac(sites, a, b; distance=euclidean)
+function edge_dac!(grid, sites, a, b; distance=euclidean)
     all(a .!= b) && throw(ArgumentError("Points $a and $b must be vertically or horizontally aligned"))
-    closest = find_closest_site.((a, b), Ref(sites); distance=distance)
+    closest = find_closest_site!(grid, a, sites; distance=distance), find_closest_site!(grid, b, sites; distance=distance)
     sum(abs, a .- b) == 1 && return closest
     if closest[1] == closest[2]
-        return Iterators.repeated(closest, sum(abs, a .- b))
+        return Iterators.repeated(closest[1], sum(abs, a .- b))
     else
         c = (a .+ b) .÷ 2
         d = c .+ (a[1] == b[1] ? (0, 1) : (1, 0))
-        return Iterators.flatten((edge_dac(sites, a, c), edge_dac(sites, b, d)))
+        return Iterators.flatten(edge_dac!(grid, sites, a, c), edge_dac!(grid, sites, b, d))
     end
 end

--- a/src/elimination_methods.jl
+++ b/src/elimination_methods.jl
@@ -36,3 +36,15 @@ function exact_aux(sites, TL, BR)
     predicate(site) = all(TL .<= site .<= BR) || exact_condition(site, sites, TL, BR)
     return early_stop_sort!(sites, predicate)
 end
+
+function edge_aux(sites, TL, BR)
+    corners = get_corners(TL, BR)
+    keep_per_edge = Iterators.map(1:4) do i
+        j = mod(i, 4) + 1
+        edge_cells = get_edge(corners[i], corners[j])
+        return Iterators.map(cell -> find_closest_site(cell, sites), edge_cells)
+    end
+    sites_to_keep = Iterators.flatten(keep_per_edge)
+    predicate(site) = all(TL .<= site .<= BR) || site in sites_to_keep
+    return early_stop_sort!(sites, predicate)
+end

--- a/src/elimination_methods.jl
+++ b/src/elimination_methods.jl
@@ -40,7 +40,7 @@ end
 function naive_edge_aux!(grid, sites, TL, BR; distance=euclidean)
     corners = get_corners(TL, BR)
     edges = (CartesianIndex(corners[a]...):CartesianIndex(corners[b]...) for (a, b) in zip((1, 1, 2, 4), (2, 4, 3, 3)))
-    sites_to_keep = (find_closest_site!(grid, Coord(Tuple(I)), sites; distance=distance) for I in edge for edge in edges)
+    sites_to_keep = (find_closest_site!(grid, Coord(Tuple(I)), sites; distance=distance) for edge in edges for I in edge)
     predicate(site) = all(TL .<= site .<= BR) || site in sites_to_keep
     return early_stop_sort!(sites, predicate)
 end

--- a/src/elimination_methods.jl
+++ b/src/elimination_methods.jl
@@ -36,32 +36,3 @@ function exact_aux(grid, sites, TL, BR; distance=euclidean)
     predicate(site) = all(TL .<= site .<= BR) || exact_condition(site, sites, TL, BR; distance=distance)
     return early_stop_sort!(sites, predicate)
 end
-
-function naive_edge_aux!(grid, sites, TL, BR; distance=euclidean)
-    corners = get_corners(TL, BR)
-    edges = (CartesianIndex(corners[a]...):CartesianIndex(corners[b]...) for (a, b) in zip((1, 1, 2, 4), (2, 4, 3, 3)))
-    sites_to_keep = (find_closest_site!(grid, Coord(Tuple(I)), sites; distance=distance) for edge in edges for I in edge)
-    predicate(site) = all(TL .<= site .<= BR) || site in sites_to_keep
-    return early_stop_sort!(sites, predicate)
-end
-
-function dac_edge_aux!(grid, sites, TL, BR; distance=euclidean)
-    corners = get_corners(TL, BR)
-    edges = ((corners[a], corners[b]) for (a, b) in zip((1, 1, 2, 4), (2, 4, 3, 3)))
-    sites_to_keep = (edge_dac!(grid, sites, edge[1], edge[2], distance=distance) for edge in edges)
-    predicate(site) = all(TL .<= site .<= BR) || site in sites_to_keep
-    return early_stop_sort!(sites, predicate)
-end
-
-function edge_dac!(grid, sites, a, b; distance=euclidean)
-    all(a .!= b) && throw(ArgumentError("Points $a and $b must be vertically or horizontally aligned"))
-    closest = find_closest_site!(grid, a, sites; distance=distance), find_closest_site!(grid, b, sites; distance=distance)
-    sum(abs, a .- b) == 1 && return closest
-    if closest[1] == closest[2]
-        return Iterators.repeated(closest[1], sum(abs, a .- b))
-    else
-        c = (a .+ b) .÷ 2
-        d = c .+ (a[1] == b[1] ? (0, 1) : (1, 0))
-        return (edge_dac!(grid, sites, a, c), edge_dac!(grid, sites, b, d))
-    end
-end

--- a/src/elimination_methods.jl
+++ b/src/elimination_methods.jl
@@ -39,8 +39,8 @@ end
 
 function naive_edge_aux!(grid, sites, TL, BR; distance=euclidean)
     corners = get_corners(TL, BR)
-    coordinates = (CartesianIndex(corners[a]...):CartesianIndex(corners[b]...) for (a, b) in zip((1, 1, 2, 4), (2, 4, 3, 3)))
-    sites_to_keep = (find_closest_site!(grid, Coord(Tuple(I)), sites; distance=distance) for I in coordinates)
+    edges = (CartesianIndex(corners[a]...):CartesianIndex(corners[b]...) for (a, b) in zip((1, 1, 2, 4), (2, 4, 3, 3)))
+    sites_to_keep = (find_closest_site!(grid, Coord(Tuple(I)), sites; distance=distance) for I in edge for edge in edges)
     predicate(site) = all(TL .<= site .<= BR) || site in sites_to_keep
     return early_stop_sort!(sites, predicate)
 end
@@ -62,6 +62,6 @@ function edge_dac!(grid, sites, a, b; distance=euclidean)
     else
         c = (a .+ b) .÷ 2
         d = c .+ (a[1] == b[1] ? (0, 1) : (1, 0))
-        return Iterators.flatten(edge_dac!(grid, sites, a, c), edge_dac!(grid, sites, b, d))
+        return (edge_dac!(grid, sites, a, c), edge_dac!(grid, sites, b, d))
     end
 end

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -60,7 +60,7 @@ Returns a tuple containing top-left (TL) and bottom-right (BR) corners for each 
 """
 function get_quadrants(TL, BR)
     MID_TL = (TL .+ BR) .÷ 2
-    MID_BR = TL .+ BR .- MID_TL
+    MID_BR = MID_TL .+ 1
     return (
         (TL, MID_TL),
         ((MID_BR[1], TL[2]), (BR[1], MID_TL[2])),

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -1,7 +1,3 @@
-function distance(x, y, p=2)
-    return norm(x .- y, p)
-end
-
 """
     get_corners(TL, BR)
 
@@ -74,17 +70,17 @@ function get_quadrants(TL, BR)
 end
 
 """
-    find_closest_site(cell, sites, p=2)
+    find_closest_site(cell, sites; distance=euclidean)
 
-See name. `p` is which Lᵖ norm to use.
+Returns the closest site to `cell` in `sites` determined by `distance`.
 """
-function find_closest_site(cell, sites, p=2)
+function find_closest_site(cell, sites; distance=euclidean)
     first_site, rest_sites = Iterators.peel(sites)
     isnothing(rest_sites) && return first_site
-    min_dist = distance(cell, first_site, p)
+    min_dist = distance(cell, first_site)
     min_site = first_site
     for site in rest_sites
-        cur_dist = distance(cell, site, p)
+        cur_dist = distance(cell, site)
         if cur_dist < min_dist
             min_dist = cur_dist
             min_site = site

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -110,13 +110,13 @@ function label_voronoi_grid(grid; shuffle_cells=true)
 end
 
 """
-    voronoi_equality(grids...)
+    voronoi_equality(grid1, grid2; distance=euclidean)
 
 Checks equality of Voronoi diagrams accounting for the fact that there may be
 multiple correct/equivalent solutions as some sites may be the same distance
 from some cells.
 """
-function voronoi_equality(grid1, grid2)
+function voronoi_equality(grid1, grid2; distance=euclidean)
     size(grid1) == size(grid2) || throw(
         ArgumentError(
             "Grids should have the same shape, got shapes $(size(grid1)) and $(size(grid2))",
@@ -129,5 +129,3 @@ function voronoi_equality(grid1, grid2)
     end
     return true
 end
-
-voronoi_equality(grids...) = reduce(voronoi_equality, grids)

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -19,10 +19,10 @@ function get_edge(a, b)
     all(a .!= b) && throw(ArgumentError("Points $a and $b must be vertically or horizontally aligned"))
     if a[1] == b[1]
         x, y = extrema((a[2], b[2]))
-        return (SVector{2,Int}(a[1], j) for j in x:1:y)
+        return (Coord(a[1], j) for j in x:1:y)
     elseif a[2] == b[2]
         x, y = extrema((a[1], b[1]))
-        return (SVector{2,Int}(i, a[2]) for i in x:1:y)
+        return (Coord(i, a[2]) for i in x:1:y)
     end
 end
 
@@ -70,9 +70,29 @@ function get_quadrants(TL, BR)
 end
 
 """
+    find_closest_site!(grid, cell, sites; distance=euclidean)
+
+Return the closest site to `cell` in `sites` determined by `distance` but first
+check whether it has already been computed.
+"""
+function find_closest_site!(grid, cell, sites; distance=euclidean)
+    if all(grid[cell...] .== 0)
+        grid[cell...] = find_closest_site(cell, sites; distance=distance)
+    end
+    return grid[cell...]
+end
+
+function find_closest_site!(grid, I::CartesianIndex, sites; distance=euclidean)
+    if all(grid[I] .== 0)
+        grid[I] = find_closest_site(I, sites; distance=distance)
+    end
+    return grid[I]
+end
+
+"""
     find_closest_site(cell, sites; distance=euclidean)
 
-Returns the closest site to `cell` in `sites` determined by `distance`.
+Return the closest site to `cell` in `sites` determined by `distance`.
 """
 function find_closest_site(cell, sites; distance=euclidean)
     first_site, rest_sites = Iterators.peel(sites)
@@ -123,7 +143,7 @@ function voronoi_equality(grid1, grid2; distance=euclidean)
         ),
     )
     for I in CartesianIndices(grid1)
-        cell = SVector{2,Int}(Tuple(I))
+        cell = Coord(Tuple(I))
         grid1[I] == grid2[I] && continue
         distance(cell, grid1[I]) == distance(cell, grid2[I]) || return false
     end

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -11,37 +11,6 @@ end
 
 
 """
-    get_edge(TL, BR)
-
-Returns the edge (cells) between two vertically or horizontally aligned points.
-"""
-function get_edge(a, b)
-    all(a .!= b) && throw(ArgumentError("Points $a and $b must be vertically or horizontally aligned"))
-    if a[1] == b[1]
-        x, y = extrema((a[2], b[2]))
-        return (Coord(a[1], j) for j in x:1:y)
-    elseif a[2] == b[2]
-        x, y = extrema((a[1], b[1]))
-        return (Coord(i, a[2]) for i in x:1:y)
-    end
-end
-
-"""
-    get_edges(TL, BR)
-
-Returns a generator containing the cells on the border edges of the rectangle
-defined by its top-left (TL) and bottom-right (BR) corners.
-"""
-function get_edges(TL, BR)
-    corners = get_corners(TL, BR)
-    edge_cells = map(1:4) do i
-        j = mod(i, 4) + 1
-        return get_edge(corners[i], corners[j])
-    end
-    return Iterators.flatten(edge_cells)
-end
-
-"""
     swap!(v, i::Int, j::Int)
 
 Swap (in-place) the elements of `v` indexed by `i` and `j`. Does nothing if `i == j`.

--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -5,10 +5,44 @@ end
 """
     get_corners(TL, BR)
 
-Returns the corners of the rectangle defined by its top-left (TL) and bottom-right (BR) corners
+Returns the corners of the rectangle defined by its top-left (TL) and
+bottom-right (BR) corners. The order of returning is TL, TR, BR, BL such that
+the pairs of corners can be looped over to get edges.
 """
 function get_corners(TL, BR)
-    return (TL, (TL[1], BR[2]), (BR[1], TL[2]), BR)
+    return (TL, (TL[1], BR[2]), BR, (BR[1], TL[2]))
+end
+
+
+"""
+    get_edge(TL, BR)
+
+Returns the edge (cells) between two vertically or horizontally aligned points.
+"""
+function get_edge(a, b)
+    all(a .!= b) && throw(ArgumentError("Points $a and $b must be vertically or horizontally aligned"))
+    if a[1] == b[1]
+        x, y = extrema((a[2], b[2]))
+        return (SVector{2,Int}(a[1], j) for j in x:1:y)
+    elseif a[2] == b[2]
+        x, y = extrema((a[1], b[1]))
+        return (SVector{2,Int}(i, a[2]) for i in x:1:y)
+    end
+end
+
+"""
+    get_edges(TL, BR)
+
+Returns a generator containing the cells on the border edges of the rectangle
+defined by its top-left (TL) and bottom-right (BR) corners.
+"""
+function get_edges(TL, BR)
+    corners = get_corners(TL, BR)
+    edge_cells = map(1:4) do i
+        j = mod(i, 4) + 1
+        return get_edge(corners[i], corners[j])
+    end
+    return Iterators.flatten(edge_cells)
 end
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@ name = "test"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,9 +93,7 @@ end
             for aux in (exact_aux, centre_anchor_aux)
                 redac_grid = copy(grid)
                 redac_voronoi!(redac_grid, sites; distance=metric, auxiliary=aux)
-                @testset "$metric, $aux" begin
-                    @test voronoi_equality(naive_grid, redac_grid; distance=metric)
-                end
+                @test voronoi_equality(naive_grid, redac_grid; distance=metric)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using BenchmarkTools
 using Random
 using Distances
 
-using DiscreteVoronoi: get_corners, voronoi_equality, exact_condition, exact_aux, centre_anchor_aux
+using DiscreteVoronoi: get_corners, voronoi_equality, exact_condition, exact_aux, centre_anchor_aux, naive_edge_aux!, dac_edge_aux!
 using DiscreteVoronoi: EarlyStopper, early_stop_sort!
 
 const Coord = SVector{2,Int}
@@ -109,7 +109,16 @@ end
         @test voronoi_equality(redac_grid_chebyshev, naive_grid_chebyshev; distance=chebyshev)
     end
 
-    @testset "Allocations" begin
+    @testset "Auxiliary function allocations" begin
+        @test @ballocated(
+            naive_edge_aux!($grid, $locs, $TL, $(BR .÷ 2)), seconds = 1.0
+        ) == 0
+        @test @ballocated(
+            dac_edge_aux!($grid, $locs, $TL, $(BR .÷ 2)), seconds = 1.0
+        ) == 0
+    end
+
+    @testset "Main function allocations" begin
         @test @ballocated(naive_voronoi!($grid, $locs), seconds = 1.0) == 0
         @test @ballocated(dac_voronoi!($grid, $locs), seconds = 1.0) == 0
         @test @ballocated(jfa_voronoi!($grid, $locs), seconds = 1.0) == 0
@@ -118,6 +127,9 @@ end
         ) == 0
         @test @ballocated(
             redac_voronoi!($grid, $locs, auxiliary=centre_anchor_aux), seconds = 1.0
+        ) == 0
+        @test @ballocated(
+            redac_voronoi!($grid, $locs, auxiliary=dac_edge_aux!), seconds = 1.0
         ) == 0
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,80 +56,78 @@ end
         n = 500
         l = 30
         TL, BR = (1, 1), (n, n)
-        locs = random_coordinates(n, l)
+        sites = random_coordinates(n, l)
         # locs = sort([Coord(rand(1:n, 2)) for _ in 1:l]) # Possibly overlapping sites.
         grid = zeros(Coord, (n, n))
-        es3 = EarlyStopper(locs)
-        predicate3(x) = exact_condition(x, locs, TL, BR)
+        es3 = EarlyStopper(sites)
+        predicate3(x) = exact_condition(x, sites, TL, BR)
         new_es3 = early_stop_sort!(es3, predicate3)
-        @test new_es3.obj == sort(locs; by=predicate3)
+        @test new_es3.obj == sort(sites; by=predicate3)
     end
 end
 
 @testset "DiscreteVoronoi.jl" begin
-    n = 11
-    l = 3
+    n = 50
+    l = 30
     TL, BR = (1, 1), (n, n)
-    # locs = sort([Coord(rand(1:n, 2)) for _ in 1:l])
-    locs = random_coordinates(n, l) # Possibly overlapping sites.
+
+    #TODO: Test with overlapping sites.
+    #TODO: Concrete tests to ensure `naive_voronoi` is correct.
+    sites = random_coordinates(n, l)
     grid = zeros(Coord, (n, n))
 
-    naive_grid = deepcopy(grid)
-    naive_voronoi!(naive_grid, locs) # Baseline for correctness
-    dac_grid = deepcopy(grid)
-    dac_voronoi!(dac_grid, locs)
-    redac_grid = deepcopy(grid)
-    redac_voronoi!(redac_grid, locs; auxiliary=exact_aux)
-
-    # Cityblock = L1 = Taxicab
-    naive_grid_cityblock = deepcopy(grid)
-    naive_voronoi!(naive_grid_cityblock, locs; distance=cityblock)
-    dac_grid_cityblock = deepcopy(grid)
-    dac_voronoi!(dac_grid_cityblock, locs; distance=cityblock)
-    redac_grid_cityblock = deepcopy(grid)
-    redac_voronoi!(redac_grid_cityblock, locs; distance=cityblock)
-
-    # Chebyshev = L∞ = maximum norm
-    naive_grid_chebyshev = deepcopy(grid)
-    naive_voronoi!(naive_grid_chebyshev, locs; distance=chebyshev)
-    dac_grid_chebyshev = deepcopy(grid)
-    dac_voronoi!(dac_grid_chebyshev, locs; distance=chebyshev)
-    redac_grid_chebyshev = deepcopy(grid)
-    redac_voronoi!(redac_grid_chebyshev, locs; distance=chebyshev)
-
-    @testset "Correctness" begin
-        @test voronoi_equality(dac_grid, naive_grid)
-        @test voronoi_equality(redac_grid, naive_grid)
+    @testset "DAC correctness" begin
+        for metric in (euclidean, cityblock, chebyshev)
+            naive_grid = copy(grid)
+            naive_voronoi!(naive_grid, sites) # Baseline for correctness
+            dac_grid = copy(grid)
+            dac_voronoi!(dac_grid, sites)
+            @test voronoi_equality(naive_grid, dac_grid)
+        end
     end
 
-    @testset "Different Lp Norms" begin
-        @test voronoi_equality(dac_grid_cityblock, naive_grid_cityblock; distance=cityblock)
-        @test voronoi_equality(redac_grid_cityblock, naive_grid_cityblock; distance=cityblock)
-        @test voronoi_equality(dac_grid_chebyshev, naive_grid_chebyshev; distance=chebyshev)
-        @test voronoi_equality(redac_grid_chebyshev, naive_grid_chebyshev; distance=chebyshev)
+    @testset "REDAC correctness" begin
+        for metric in (euclidean, cityblock, chebyshev)
+            naive_grid = copy(grid)
+            naive_voronoi!(naive_grid, sites; distance=metric) # Baseline for correctness
+            for aux in (exact_aux, centre_anchor_aux, naive_edge_aux!, dac_edge_aux!)
+                redac_grid = copy(grid)
+                redac_voronoi!(redac_grid, sites; distance=metric, auxiliary=aux)
+                @test voronoi_equality(naive_grid, redac_grid)
+            end
+        end
     end
 
     @testset "Auxiliary function allocations" begin
         @test @ballocated(
-            naive_edge_aux!($grid, $locs, $TL, $(BR .÷ 2)), seconds = 1.0
+            exact_aux($grid, $sites, $TL, $(BR .÷ 2)), seconds = 1.0
         ) == 0
         @test @ballocated(
-            dac_edge_aux!($grid, $locs, $TL, $(BR .÷ 2)), seconds = 1.0
+            centre_anchor_aux($grid, $sites, $TL, $(BR .÷ 2)), seconds = 1.0
+        ) == 0
+        @test @ballocated(
+            naive_edge_aux!($grid, $sites, $TL, $(BR .÷ 2)), seconds = 1.0
+        ) == 0
+        @test @ballocated(
+            dac_edge_aux!($grid, $sites, $TL, $(BR .÷ 2)), seconds = 1.0
         ) == 0
     end
 
     @testset "Main function allocations" begin
-        @test @ballocated(naive_voronoi!($grid, $locs), seconds = 1.0) == 0
-        @test @ballocated(dac_voronoi!($grid, $locs), seconds = 1.0) == 0
-        @test @ballocated(jfa_voronoi!($grid, $locs), seconds = 1.0) == 0
+        @test @ballocated(naive_voronoi!($grid, $sites), seconds = 1.0) == 0
+        @test @ballocated(dac_voronoi!($grid, $sites), seconds = 1.0) == 0
+        @test @ballocated(jfa_voronoi!($grid, $sites), seconds = 1.0) == 0
         @test @ballocated(
-            redac_voronoi!($grid, $locs, auxiliary=exact_aux), seconds = 1.0
+            redac_voronoi!($grid, $sites, auxiliary=exact_aux), seconds = 1.0
         ) == 0
         @test @ballocated(
-            redac_voronoi!($grid, $locs, auxiliary=centre_anchor_aux), seconds = 1.0
+            redac_voronoi!($grid, $sites, auxiliary=centre_anchor_aux), seconds = 1.0
         ) == 0
         @test @ballocated(
-            redac_voronoi!($grid, $locs, auxiliary=dac_edge_aux!), seconds = 1.0
+            redac_voronoi!($grid, $sites, auxiliary=naive_edge_aux!), seconds = 1.0
+        ) == 0
+        @test @ballocated(
+            redac_voronoi!($grid, $sites, auxiliary=dac_edge_aux!), seconds = 1.0
         ) == 0
     end
 end


### PR DESCRIPTION
Apologies for the large, monolithic PR.

**Major change:**
Avoid recomputation as much as possible by writing directly to the grid whenever a closest site is calculated and reading the closest site before calculation. Note, this does mean that grid cells that are not identically equal to `Coord(0, 0)` will be ignored during calculation for **all** algorithms.

This change is done by defining and exporting `find_closest_site!` and changing auxiliary functions to pass the grid as an argument.

**Minor changes:**
* Define and use `Coord = SVector{2, Int}` everywhere internally,
* Change the order of `get_corners` to allow for better looping (for upcoming `edge_aux` stuff),
* Reorganise tests to adhere to DRY.

**Bugfixes:**
* Fix `auxiliary` always being `exact_aux` in `redac_voronoi`.